### PR TITLE
version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
 - 📝 **YAML-based quiz authoring**: Author quizzes in a clean, human-readable YAML format.
 - 🧠 **Support for diverse question types**: Including multiple-choice, true/false, numerical answers, comprehension passages, and more.
 - ✔️ **Multiple answer formats**: Single select, multiple select, numerical ranges, and tolerance-based answers.
-- 🔍 **Schema validation with Pydantic**: Ensures your quiz structure is validated for correctness before exporting.
+- 🔍 **Schema validation with Pydantic and Json Schema**: Ensures your quiz structure is validated for correctness before exporting.
 - 📤 **Flexible export options**: Export quizzes in **JSON**, **HTML** (print-ready), or **Markdown** formats.
 - ⚙️ **Command-line interface**: Simple CLI for validation and export operations.
 - ♻️ **Live reloading for development**: Integrated live reload server to auto-update quizzes as you edit.
 - 📐 **Mathematical equation support**: Native support for dollar-math (`$..$` and `$$..$$` ) based LaTeX-style equations for math-based quizzes.
 - 💻 **Code block rendering**: Display code snippets within quiz questions for technical assessments.
 - 💯 **Optional Scoring**: Optional scoring support.
-
+- 🛠️ **Easy Integration**: Can be easily integrated into any system as it is available as a python package.
 ---
 
 ## 📝 Answer Types
@@ -36,7 +36,7 @@ Queck supports a variety of question types, including:
     ```yaml
     answer:
       - ( ) Option 1
-      - (o) Option 2 // feedback for option 2
+      - (o) Option 2 /# feedback for option 2
       - ( ) Option 3
       - ( ) Option 4
     ```
@@ -47,7 +47,7 @@ Queck supports a variety of question types, including:
     ```yaml
     answer:
       - ( ) Option 1
-      - (x) Option 2 // feedback for option 2
+      - (x) Option 2 /# feedback for option 2f
       - ( ) Option 3
       - (x) Option 4
     ```
@@ -80,6 +80,8 @@ Queck supports a variety of question types, including:
     ```yaml
     answer: 1.3|.5
     ```
+  - **Single Floating Point Values**\
+    By default floating point values are **not supported** as a best practice. But they can be added with range or tolerance type. For example, `0.5..0.5` or `0.5|0`.
 
 - **Short Answer**\
   Yaml string.
@@ -89,6 +91,18 @@ Queck supports a variety of question types, including:
   ```
 
 ---
+
+## Other validation rules
+1. Every choice based question should have **atleast one incorrect option**. 
+2. Common data questions should have **atleast two** contextual  questions inside them.
+
+## VS Code Profile
+
+The below VS code profile contains the necessary extensions and configurations for syntax highlighting and validation of queck files. 
+
+https://gist.github.com/livinNector/596a7c507a95eaa59014df9505159ce8
+
+Check [this](https://code.visualstudio.com/docs/configure/profiles#_import) for the instructions to import the vscode profile.
 
 ## 📄 Sample Queck Format
 
@@ -123,6 +137,8 @@ pip install queck
 
 ### `qeuck format`
 
+Formats the markdown content inside the queck file using mdformat.
+
 ```bash
 queck format quiz.queck
 ```
@@ -135,11 +151,41 @@ To export a quiz in HTML format with live watching enabled:
 queck export path/to/quiz.queck --format html --output_folder export --render_mode fast --watch
 ```
 
-- `--format`: Specify output format as `html` or `md`.
+- `--format`: Specify output format as `html`,`md` or `json`.
 - `--output_folder`: Directory for exported files.
-- `--render_mode`: Use `fast` for KaTeX and Highlight.js `compat` for inline styles, `latex` for using Latex.css.
+- `--render_mode`: (For html export only) Use `fast` for KaTeX and Highlight.js `compat` for inline styles, `latex` for using Latex.css.
+
+Shorthands for options are also supported.
+
+```bash
+queck export path/to/quiz.queck -f html -o export -r fast -w
+```
 
 ---
+
+## Experimental GenAI Features
+
+To enable this feature install queck using the following extras.
+
+```bash
+uv tool install "queck[genai]"
+```
+
+### `queck extract`
+
+To extract questions from text based formats like markdown or latex.
+
+```bash
+queck extract path/to/file.md --model "openai:gpt-4o-mini"
+```
+
+The model is provided with the format `{provider}:{model_name}`
+
+Available providers:
+  - `openai`
+  - `groq`
+
+
 
 ## 🤝 Contribution
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@
 Queck supports a variety of question types, including:
 
 - **Choice Based**
+  - The separater `/#` is used to mark option-wise feedback. To use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.
   - **Single Select Choices**\
-    list of yaml string marked with `(o)` resembling resembling radio button.
+    List of yaml string marked with `(o)` resembling resembling radio button.
 
     ```yaml
     answer:
@@ -47,8 +48,8 @@ Queck supports a variety of question types, including:
     ```yaml
     answer:
       - ( ) Option 1
-      - (x) Option 2 /# feedback for option 2f
-      - ( ) Option 3
+      - (x) Option 2 /# feedback for option 2
+      - ( ) Option 3 /# feedback for option 3
       - (x) Option 4
     ```
 

--- a/examples/sample_quiz.queck
+++ b/examples/sample_quiz.queck
@@ -1,6 +1,6 @@
 title: Sample Quiz
 questions:
-  # Single Select choice questions with individiual feedback
+  # Single Select questions with individiual feedback
   - text: What is the capital of **France**?
     answer:
       - (o) Paris /# correct
@@ -17,6 +17,7 @@ questions:
       - ( ) HTML
       - ( ) CSS
     feedback: HTML and CSS are markup and styling language respectively
+    tags: [easy, programming]
     marks: 2
 
   # numerical or short answer type
@@ -64,7 +65,7 @@ questions:
         ```
 
       - |-
-        (x) ```
+        (o) ```
         hi
         hi 
         ```
@@ -80,7 +81,7 @@ questions:
       - ( ) The code has syntax errors
     marks: 2
 
-  # Comprehension question
+  # Common Data questions
   - text: |-
       The following questions are about the solar system. Read the below passage
       before answering.
@@ -95,7 +96,7 @@ questions:
       - text: Which planet is known as the Red Planet?
         answer:
           - ( ) Earth
-          - (x) Mars
+          - (o) Mars
           - ( ) Jupiter
           - ( ) Saturn
         marks: 2

--- a/examples/sample_quiz.queck
+++ b/examples/sample_quiz.queck
@@ -3,10 +3,11 @@ questions:
   # Multiple choice questions with individiual feedback
   - text: What is the capital of **France**?
     answer:
-      - (x) Paris // correct
-      - ( ) London // London is the capital of Britian
-      - ( ) Berlin // Berlin is the capital of Germany
-      - ( ) Madrid // Madrid is the capital of Spain
+      - (x) Paris /# correct
+      - ( ) London /# London is the capital of Britian
+      - ( ) Berlin /# Berlin is the capital of Germany
+      - ( ) Madrid /# Madrid is the capital of Spain
+      - ( ) alsdkjfhla skdjfh /# asl;dkfj
     marks: 2
 
   # Multiple Select question with global feedback

--- a/examples/sample_quiz.queck
+++ b/examples/sample_quiz.queck
@@ -1,13 +1,12 @@
 title: Sample Quiz
 questions:
-  # Multiple choice questions with individiual feedback
+  # Single Select choice questions with individiual feedback
   - text: What is the capital of **France**?
     answer:
-      - (x) Paris /# correct
+      - (o) Paris /# correct
       - ( ) London /# London is the capital of Britian
       - ( ) Berlin /# Berlin is the capital of Germany
       - ( ) Madrid /# Madrid is the capital of Spain
-      - ( ) alsdkjfhla skdjfh /# asl;dkfj
     marks: 2
 
   # Multiple Select question with global feedback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "queck"
-version = "1.0.5"
+version = "2.0.0"
 description = "A quiz authoring format and tool with different export formats."
 readme = "README.md"
 authors = [{ name = "Livin Nector", email = "livinnector2001@gmail.com" }]
@@ -46,7 +46,7 @@ build-backend = "setuptools.build_meta"
 queck = "queck.cli:main"
 
 [project.optional-dependencies]
-genai = ["langchain-openai>=0.3.9"]
+genai = ["langchain-groq>=0.3.2", "langchain-openai>=0.3.9"]
 
 [dependency-groups]
 dev = ["ipykernel>=6.29.5", "pytest>=8.3.4", "ruff>=0.7.3"]

--- a/schema/queck_schema.json
+++ b/schema/queck_schema.json
@@ -69,7 +69,7 @@
     },
     "IncorrectChoice": {
       "default": "",
-      "description": "Incorrect Choice in a multiple choice question.\n\nFormat: `( ) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use the keyword `\\shash` (short for slash and hash).\n\nExamples:\n```yaml\n- ( ) incorrect choice /# This is the incorrect answer\n- ( ) another incorrect choice\n- |\n    ( ) This is another incorrect choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback.\n```",
+      "description": "Incorrect Choice in a multiple choice question.\n\nFormat: `( ) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.\n\nExamples:\n```yaml\n- ( ) incorrect choice /# This is the incorrect answer\n- ( ) another incorrect choice\n- |\n    ( ) This is another incorrect choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback.\n- ( ) This has /&#35; separator in the text.\n```",
       "pattern": "^ *\\( \\) *(?<text>(.|\\r?\\n)*?) *(/# *(?<feedback>(.|\\r?\\n)*))?$",
       "title": "IncorrectChoice",
       "type": "string"
@@ -112,7 +112,7 @@
     },
     "MultipleSelectCorrectChoice": {
       "default": "",
-      "description": "Correct Choice in a multiple select question.\n\nThe mark resembles checkboxes (x).\n\nFormat: `(x) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use the keyword `\\shash` (short for slash and hash).\n\nExamples:\n```yaml\n- (x) correct choice /# This is the correct answer\n- (x) another correct choice\n- |\n    (x) This is another correct choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback\n```",
+      "description": "Correct Choice in a multiple select question.\n\nThe mark resembles checkboxes (x).\n\nFormat: `(x) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.\n\nExamples:\n```yaml\n- (x) correct choice /# This is the correct answer\n- (x) another correct choice\n- |\n    (x) This is another correct choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback\n- (x) This has /&#35; separator in the text.\n```",
       "pattern": "^ *\\(x\\) *(?<text>(.|\\r?\\n)*?) *(/# *(?<feedback>(.|\\r?\\n)*))?$",
       "title": "MultipleSelectCorrectChoice",
       "type": "string"
@@ -265,7 +265,7 @@
     },
     "SingleSelectCorrectChoice": {
       "default": "",
-      "description": "Correct Choice in a single select question.\n\nThe mark resembles (o) radio button.\n\nFormat: `(o) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use the keyword `\\shash` (short for slash and hash).\n\nExamples:\n```yaml\n- (o) correct choice /# This is the correct answer\n- (o) another correct choice\n- |\n    (o) This is another correct choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback\n```",
+      "description": "Correct Choice in a single select question.\n\nThe mark resembles (o) radio button.\n\nFormat: `(o) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.\n\nExamples:\n```yaml\n- (o) correct choice /# This is the correct answer\n- (o) another correct choice\n- |\n    (o) This is another correct choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback\n- (o) This has /&#35; separator in the text.\n```",
       "pattern": "^ *\\(o\\) *(?<text>(.|\\r?\\n)*?) *(/# *(?<feedback>(.|\\r?\\n)*))?$",
       "title": "SingleSelectCorrectChoice",
       "type": "string"

--- a/schema/queck_schema.json
+++ b/schema/queck_schema.json
@@ -69,8 +69,8 @@
     },
     "IncorrectChoice": {
       "default": "",
-      "description": "Incorrect Choice in a multiple choice question.\n\nFormat: `( ) {text} // {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nExamples:\n    - ( ) incorrect choice // This is the incorrect answer\n    - ( ) another incorrect choice\n    - |\n      ( ) This is another incorrect choice\n      That can span muliple lines.\n      // This is going to be a multiline feedback\n      and this is the second line of the feedback.",
-      "pattern": "\\( \\) *(?<text>(.|\\r?\\n)*?) *(// *(?<feedback>(.|\\r?\\n)*))?$",
+      "description": "Incorrect Choice in a multiple choice question.\n\nFormat: `( ) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use the keyword `\\shash` (short for slash and hash).\n\nExamples:\n```yaml\n- ( ) incorrect choice /# This is the incorrect answer\n- ( ) another incorrect choice\n- |\n    ( ) This is another incorrect choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback.\n```",
+      "pattern": "^ *\\( \\) *(?<text>(.|\\r?\\n)*?) *(/# *(?<feedback>(.|\\r?\\n)*))?$",
       "title": "IncorrectChoice",
       "type": "string"
     },
@@ -112,8 +112,8 @@
     },
     "MultipleSelectCorrectChoice": {
       "default": "",
-      "description": "Correct Choice in a multiple select question.\n\nThe mark resembles checkboxes (x).\n\nFormat: `(x) {text} // {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nExamples:\n    - (x) correct choice // This is the correct answer\n    - (x) another correct choice\n    - |\n      (x) This is another correct choice\n      That can span muliple lines.\n      // This is going to be a multiline feedback\n      and this is the second line of the feedback",
-      "pattern": "\\(x\\) *(?<text>(.|\\r?\\n)*?) *(// *(?<feedback>(.|\\r?\\n)*))?$",
+      "description": "Correct Choice in a multiple select question.\n\nThe mark resembles checkboxes (x).\n\nFormat: `(x) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use the keyword `\\shash` (short for slash and hash).\n\nExamples:\n```yaml\n- (x) correct choice /# This is the correct answer\n- (x) another correct choice\n- |\n    (x) This is another correct choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback\n```",
+      "pattern": "^ *\\(x\\) *(?<text>(.|\\r?\\n)*?) *(/# *(?<feedback>(.|\\r?\\n)*))?$",
       "title": "MultipleSelectCorrectChoice",
       "type": "string"
     },
@@ -265,8 +265,8 @@
     },
     "SingleSelectCorrectChoice": {
       "default": "",
-      "description": "Correct Choice in a single select question.\n\nThe mark resembles (o) radio button.\n\nFormat: `(o) {text} // {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nExamples:\n    - (o) correct choice // This is the correct answer\n    - (o) another correct choice\n    - |\n      (o) This is another correct choice\n      That can span muliple lines.\n      // This is going to be a multiline feedback\n      and this is the second line of the feedback",
-      "pattern": "\\(o\\) *(?<text>(.|\\r?\\n)*?) *(// *(?<feedback>(.|\\r?\\n)*))?$",
+      "description": "Correct Choice in a single select question.\n\nThe mark resembles (o) radio button.\n\nFormat: `(o) {text} /# {feedback}`\n    - `text` is the choice content\n    - `feedback` is optional and explains the correctness or\n    details about the choice\n\nBoth text and feedback can span multiple lines.\n\nThe sequence `/#` acts the feedback separater in chocies.\nTo use the literal `/#`, use the keyword `\\shash` (short for slash and hash).\n\nExamples:\n```yaml\n- (o) correct choice /# This is the correct answer\n- (o) another correct choice\n- |\n    (o) This is another correct choice\n    That can span muliple lines.\n    /# This is going to be a multiline feedback\n    and this is the second line of the feedback\n```",
+      "pattern": "^ *\\(o\\) *(?<text>(.|\\r?\\n)*?) *(/# *(?<feedback>(.|\\r?\\n)*))?$",
       "title": "SingleSelectCorrectChoice",
       "type": "string"
     },

--- a/src/queck/answer_models.py
+++ b/src/queck/answer_models.py
@@ -119,11 +119,11 @@ class PatternStringBase(abc.ABC, RootModel):
 
 
 def escape_choice(text):
-    return re.sub(r"/#", r"\\shash", text)
+    return re.sub(r"/#", r"/&#35;", text)
 
 
 def unescape_choice(text):
-    return re.sub(r"\\shash", r"/#", text)
+    return re.sub(r"(/&#35;|&#47;#|&#47;&#35;)", r"/#", text)
 
 
 def format_choice(mark, text, feedback):
@@ -184,7 +184,7 @@ class SingleSelectCorrectChoice(ChoiceBase):
     Both text and feedback can span multiple lines.
 
     The sequence `/#` acts the feedback separater in chocies.
-    To use the literal `/#`, use the keyword `\shash` (short for slash and hash).
+    To use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.
 
     Examples:
     ```yaml
@@ -195,6 +195,7 @@ class SingleSelectCorrectChoice(ChoiceBase):
         That can span muliple lines.
         /# This is going to be a multiline feedback
         and this is the second line of the feedback
+    - (o) This has /&#35; separator in the text.
     ```
     """
 
@@ -218,7 +219,7 @@ class MultipleSelectCorrectChoice(ChoiceBase):
     Both text and feedback can span multiple lines.
 
     The sequence `/#` acts the feedback separater in chocies.
-    To use the literal `/#`, use the keyword `\shash` (short for slash and hash).
+    To use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.
 
     Examples:
     ```yaml
@@ -229,6 +230,7 @@ class MultipleSelectCorrectChoice(ChoiceBase):
         That can span muliple lines.
         /# This is going to be a multiline feedback
         and this is the second line of the feedback
+    - (x) This has /&#35; separator in the text.
     ```
     """
 
@@ -250,7 +252,7 @@ class IncorrectChoice(ChoiceBase):
     Both text and feedback can span multiple lines.
 
     The sequence `/#` acts the feedback separater in chocies.
-    To use the literal `/#`, use the keyword `\shash` (short for slash and hash).
+    To use the literal `/#`, use html code for / (&#47;) or # (&#35;) or both.
 
     Examples:
     ```yaml
@@ -261,6 +263,7 @@ class IncorrectChoice(ChoiceBase):
         That can span muliple lines.
         /# This is going to be a multiline feedback
         and this is the second line of the feedback.
+    - ( ) This has /&#35; separator in the text.
     ```
     """
 

--- a/src/queck/extract.py
+++ b/src/queck/extract.py
@@ -41,9 +41,9 @@ class NoDefaultJsonSchema(GenerateJsonSchema):
 
 
 def get_model(model_name):
-    model_name = model_name or "open-ai:gpt-4o-mini"
+    model_name = model_name or "openai:gpt-4o-mini"
     provider, model_name = model_name.split(":")
-    if provider == "open-ai":
+    if provider == "openai":
         return ChatOpenAI(model=model_name or "gpt-4o-mini").with_structured_output(
             Quiz.model_json_schema(schema_generator=NoDefaultJsonSchema),
             method="json_schema",

--- a/src/queck/extract.py
+++ b/src/queck/extract.py
@@ -1,7 +1,10 @@
 from importlib.resources import files
 
 from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda
+from langchain_groq import ChatGroq
 from langchain_openai import ChatOpenAI
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 
 from . import prompts
 from .queck_models import Queck
@@ -22,9 +25,44 @@ quiz_extraction_prompt = ChatPromptTemplate(
 )
 
 
+def remove_defaults(schema: dict) -> dict:
+    if isinstance(schema, dict):
+        return {k: remove_defaults(v) for k, v in schema.items() if k != "default"}
+    elif isinstance(schema, list):
+        return [remove_defaults(item) for item in schema]
+    return schema
+
+
+class NoDefaultJsonSchema(GenerateJsonSchema):
+    def generate(self, schema, mode: str = "validation") -> JsonSchemaValue:
+        original_schema = super().generate(schema, mode=mode)
+        cleaned_schema = remove_defaults(original_schema)
+        return cleaned_schema
+
+
 def get_model(model_name):
-    return ChatOpenAI(model=model_name or "gpt-4o-mini").with_structured_output(
-        Quiz, method="json_mode"
+    model_name = model_name or "open-ai:gpt-4o-mini"
+    provider, model_name = model_name.split(":")
+    if provider == "open-ai":
+        return ChatOpenAI(model=model_name or "gpt-4o-mini").with_structured_output(
+            Quiz.model_json_schema(schema_generator=NoDefaultJsonSchema),
+            method="json_schema",
+        )
+    elif provider == "groq":
+        return ChatGroq(
+            model=model_name or "llama-3.1-8b-instant"
+        ).with_structured_output(Quiz.model_json_schema(), method="json_mode")
+
+
+def get_validator(fix_multi_select=True, force_single_select=False):
+    return RunnableLambda(
+        lambda x: Quiz.model_validate(
+            x,
+            context={
+                "fix_multi_select": fix_multi_select,
+                "force_single_select": force_single_select,
+            },
+        )
     )
 
 
@@ -38,13 +76,18 @@ def quiz2queck(quiz: Quiz):
 
 def prompt_queck(prompt: str, model_name: None):
     model = get_model(model_name)
-    quiz_extraction_chain = quiz_extraction_prompt | model
+
+    quiz_extraction_chain = quiz_extraction_prompt | model | get_validator()
     return quiz2queck(quiz_extraction_chain.invoke({"text": prompt}))
 
 
-def extract_queck(file_name, model_name=None):
+def extract_queck(file_name, model_name=None, force_single_select=True):
     model = get_model(model_name)
-    quiz_extraction_chain = quiz_extraction_prompt | model
+    quiz_extraction_chain = (
+        quiz_extraction_prompt
+        | model
+        | get_validator(force_single_select=force_single_select)
+    )
     with open(file_name) as f:
         content = f.read()
     quiz = quiz_extraction_chain.invoke({"text": content})

--- a/src/queck/prompts/quiz_extraction_prompt.txt
+++ b/src/queck/prompts/quiz_extraction_prompt.txt
@@ -3,6 +3,8 @@ Do not modify, add or remove any content or info or correct any mistakes from th
 
 Ensure that all the choices are marked correct or wrong according to the question.
 Ensure that only one correct option in single select choices.
+Extract the contents of the choices as markdown. Use code blocks and dollar math blocks in choices as needed.
+Common Data Questions wont have answer instead it has a list of question nested inside it.
 
 Content:
 {text}

--- a/src/queck/prompts/quiz_structure.txt
+++ b/src/queck/prompts/quiz_structure.txt
@@ -1,43 +1,64 @@
-You are a Quiz generator who generates quiz in the below json structure.
+You are a Quiz agent who creates, extract or manipulates quiz in the below json structure.
 
 Quiz Model structure:
 
-Choice:
-  text: str
-  feedback: str = ""
-  is_correct: bool
-  type: Literal['single_select', 'multiple_select'] # this attribute is added only for if correct
-
-Range:
-  low: int | float
-  high: int | float
-
-Tolerance:
-  value: int|float
-  tolerance: int|float
-
-
-Answer:
-  value: [int|str|bool|list[Choice]|Range|Tolerance]
-  type: Literal['num_int', 'short_answer', 'true_false', 'single_select_choices', 'multiple_select_choices', 'num_range', 'num_tolerance']
-
-Question:
-  text: str
-  answer: Answer
-  feedback: str = ""
-  marks: int | float = 0
-  tags: list[str] = []
-
-CommonDataQuestion:
-  text: str
-  questions : list[Question]
-
-Description:
+class Choice(BaseModel):
     text: str
+    feedback: Optional[str] = None
+    is_correct: bool
+    type: Optional[Literal['single_select', 'multiple_select']] = None  # only present if correct
 
-Quiz:
-  title: str
-  questions: list[Question|CommonDataQuestion|Description]
+
+class Range(BaseModel):
+    low: float
+    high: float
+
+
+class Tolerance(BaseModel):
+    value: float
+    tolerance: float
+
+
+class Answer(BaseModel):
+    type: Literal[
+        'num_int',
+        'short_answer',
+        'true_false',
+        'single_select_choices',
+        'multiple_select_choices',
+        'num_range',
+        'num_tolerance'
+    ]
+    value: Union[
+        int,
+        str,
+        bool,
+        List[Choice],
+        Range,
+        Tolerance
+    ]
+
+
+class Question(BaseModel):
+    text: str
+    answer: Answer
+    feedback: Optional[str] = None
+    marks: Optional[float] = None
+    tags: Optional[List[str]] = None
+
+
+class CommonDataQuestion(BaseModel):
+    text: str  # Shared prompt for related questions
+    questions: List[Question]
+
+
+class Description(BaseModel):
+    text: str  # Text-only content for instructions or section headers
+
+
+class Quiz(BaseModel):
+    title: str
+    questions: List[Union[Question, CommonDataQuestion, Description]]
 
 
 The text content should be always in github flavoured markdown and not in any other formats.

--- a/src/queck/queck_models.py
+++ b/src/queck/queck_models.py
@@ -162,6 +162,9 @@ class CommonDataQuestion(QuestionBase):
         return m
 
 
+QueckItem = Description | Question | CommonDataQuestion
+
+
 class Queck(BaseModel):
     """Represents a YAML-based quiz format.
 
@@ -174,7 +177,7 @@ class Queck(BaseModel):
     """
 
     title: str = Field(default="Queck Title", description="The title of the quiz.")
-    questions: list[Description | Question | CommonDataQuestion] = Field(
+    questions: list[QueckItem] = Field(
         description="A collection of questions, "
         "which may include standalone questions or common-data questions.",
     )

--- a/src/queck/quiz_models.py
+++ b/src/queck/quiz_models.py
@@ -79,7 +79,9 @@ class Choices(RootModel):
 
     @model_validator(mode="after")
     @classmethod
-    def alteast_one_correct(cls, value):
+    def alteast_one_correct(cls, value, info: ValidationInfo):
+        if info.context and info.context.get("ignore_n_correct"):
+            return value
         assert value.n_correct > 0, "Atleast one choice must be correct"
         assert value.n_correct < len(value.root), "All choices should not be correct"
         return value
@@ -130,20 +132,16 @@ class Answer(BaseModel):
         # Change to multi select if more than one correct option is there
 
         if info.context:
-            if info.context["fix_multi_select"]:
-                match value := self.value:
-                    case Choices():
-                        if value.n_correct > 1:
-                            self.type = "multiple_select_choices"
+            match value := self.value:
+                case Choices():
+                    if value.n_correct > 1 and info.context.get("fix_multiple_select"):
+                        self.type = "multiple_select_choices"
                         for choice in iter(value):
                             if choice.is_correct:
                                 choice.type = "multiple_select"
 
-            if info.context["force_single_select"]:
-                match value := self.value:
-                    case Choices():
-                        if value.n_correct == 1:
-                            self.type = "single_select_choices"
+                    if value.n_correct == 1 and info.context.get("force_single_select"):
+                        self.type = "single_select_choices"
                         for choice in iter(value):
                             if choice.is_correct:
                                 choice.type = "single_select"

--- a/src/queck/templates/queck_template.md.jinja
+++ b/src/queck/templates/queck_template.md.jinja
@@ -67,7 +67,7 @@
 {{-"\n\n</div>\n" if format=='html' else ''}}
 {%for question in item.questions -%}
 {{-'\n<div class="no-break">\n' if format=='html' else ''-}}
-{{ render_question(question, index+0.1*loop.index, level=3) }}
+{{ render_question(question, index~"."~loop.index, level=3) }}
 {{-"\n</div>" if format=='html' else ''-}}
 {%- endfor -%}
 {%- else -%}

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -65,41 +65,62 @@ def queck_fixture():
 
 
 @pytest.mark.parametrize(
-    "choice_str, expected_text, expected_feedback, is_correct",
+    "choice_str, expected_text, expected_feedback, is_correct, is_single_select",
     [
-        ("(x) Correct Choice // Explanation", "Correct Choice", "Explanation", True),
         (
-            "( ) Incorrect Choice // Explanation",
-            "Incorrect Choice",
-            "Explanation",
-            False,
-        ),
-        (
-            "(x) Correct Choice Line 1  \nLine 2 // Explanation Line 1  \nLine 2",
-            "Correct Choice Line 1\\\nLine 2",
-            "Explanation Line 1\\\nLine 2",
-            True,
-        ),
-        ("( )\nCorrect Choice\n// Explanation", "Correct Choice", "Explanation", False),
-        (
-            "(x)\nCorrect Choice\n\n\n// \n\nExplanation\n\n",
+            "(x) Correct Choice /# Explanation",
             "Correct Choice",
             "Explanation",
             True,
+            False,
+        ),
+        (
+            "(o) Correct Choice /# Explanation",
+            "Correct Choice",
+            "Explanation",
+            True,
+            True,
+        ),
+        (
+            "( ) Incorrect Choice /# Explanation",
+            "Incorrect Choice",
+            "Explanation",
+            False,
+            False,
+        ),
+        (
+            "(x) Correct Choice Line 1  \nLine 2 /# Explanation Line 1  \nLine 2",
+            "Correct Choice Line 1\\\nLine 2",
+            "Explanation Line 1\\\nLine 2",
+            True,
+            False,
+        ),
+        (
+            "( )\nCorrect Choice\n/# Explanation",
+            "Correct Choice",
+            "Explanation",
+            False,
+            False,
+        ),
+        (
+            "(x)\nCorrect Choice\n\n\n/# \n\nExplanation\n\n",
+            "Correct Choice",
+            "Explanation",
+            True,
+            False,
         ),
     ],
 )
-def test_choices(choice_str, expected_text, expected_feedback, is_correct):
-    instantiated = (
-        MultipleSelectCorrectChoice(root=choice_str)
+def test_choices(
+    choice_str, expected_text, expected_feedback, is_correct, is_single_select
+):
+    model_type = (
+        (SingleSelectCorrectChoice if is_single_select else MultipleSelectCorrectChoice)
         if is_correct
-        else IncorrectChoice(root=choice_str)
+        else IncorrectChoice
     )
-    validated = (
-        MultipleSelectCorrectChoice.model_validate(choice_str)
-        if is_correct
-        else IncorrectChoice.model_validate(choice_str)
-    )
+    instantiated = model_type(root=choice_str)
+    validated = model_type.model_validate(choice_str)
 
     assert instantiated == validated
     assert instantiated.text == expected_text

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -64,6 +64,17 @@ def queck_fixture():
     )
 
 
+def test_choice_feedback_escape():
+    choice = SingleSelectCorrectChoice(root="(o) option 1 /# feedback")
+    choice_with_shash = SingleSelectCorrectChoice(
+        root="(o) option 1 with /&#35; &#47;# &#47;&#35; "
+        "/# feedback with /&#35; &#47;# &#47;&#35;"
+    )
+    assert choice.feedback == "feedback"
+    assert choice_with_shash.text == "option 1 with /# /# /#"
+    assert choice_with_shash.feedback == "feedback with /# /# /#"
+
+
 @pytest.mark.parametrize(
     "choice_str, expected_text, expected_feedback, is_correct, is_single_select",
     [


### PR DESCRIPTION
Breaking changes:
 - Changed the separator for the option-wise feedback to /# instead of // as it is often used as a special character in codes blocks.
 
Other changes:
 - Improved queck extraction from [genai] extras.
 - Added tests for different choices and escaping.
 - Added groq as a provider in queck extract
 - Update readme

Fixes:
- Fixed long floating point in HTML and markdown exports for contextual questions.
- Fix choice regex in pydantic model and json schema
